### PR TITLE
issue/#9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.3.4",
         "bootstrap": "^5.2.3",
         "json-server": "^0.17.2",
         "react": "^18.2.0",
@@ -5143,6 +5144,29 @@
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14802,6 +14826,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -21762,6 +21791,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg=="
     },
+    "axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
@@ -28590,6 +28641,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.3.4",
     "bootstrap": "^5.2.3",
     "json-server": "^0.17.2",
     "react": "^18.2.0",

--- a/src/home/components/AddEmployee/index.jsx
+++ b/src/home/components/AddEmployee/index.jsx
@@ -1,65 +1,154 @@
-import { useState } from 'react'
 import { Button, Container, Form, Row, Col } from 'react-bootstrap'
+import { actions, selectors } from './store'
 
 const AddEmployee = () => {
+  const submited = selectors.useSubmited()
+  const nameIsInvalid = selectors.useNameIsInvalid()
+  const sexIsInvalid = selectors.useSexIsInvalid()
+  const birthdayIsInvalid = selectors.useBirthdayIsInvalid()
+  const addressIsInvalid = selectors.useAddressIsInvalid()
+  const workYearIsInvalid = selectors.useWorkYaerIsInvalid()
+  const phoneNumberIsInvalid = selectors.usePhoneNumberIsInvalid()
+  const adminMailAddressIsInvalid = selectors.useAdminMailAddressIsInvalid()
+  const isAdmin = selectors.useIsAdmin()
+  const setName = actions.useSetName()
+  const setSex = actions.useSetSex()
+  const setBirthday = actions.useSetBirthday()
+  const setAddress = actions.useSetAddress()
+  const setWorkYear = actions.useSetWorkYaer()
+  const setPhoneNumber = actions.useSetPhoneNumber()
+  const setIdAdmin = actions.useSetIsAdmin()
+  const setAdminMailAddress = actions.useSetAdminMailAddress()
+  const setTrueSubmited = actions.useSetTrueSubmited()
 
-  // TODO: recoilに書き換える(UIのみ表示のタスクのため、useStateを使用)
-  const [check, setCheck] = useState(false)
+  const handleSubmit = (event) => {
+    const form = event.currentTarget;
+    setTrueSubmited()
+    if (form.checkValidity() === false) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
 
   return (
     <Container>
       <h2 className='text-primary'>メンバー新規追加</h2>
-      <Form className='shadow bg-white rounded p-3'>
+      <Form
+        noValidate
+        className='shadow bg-white rounded p-3'
+        onSubmit={handleSubmit}
+      >
         <Row className="justify-content-center">
           <Col md={2}>
             <Form.Group className="mb-3" controlId="name">
               <Form.Label>お名前 :</Form.Label>
-              <Form.Control type='input' />
+              <Form.Control
+                required
+                type='input'
+                onChange={(event) => {
+                  setName(event.target.value)
+                }}
+                isInvalid={submited && nameIsInvalid}
+              />
+              <Form.Control.Feedback type="invalid">
+                入力欄が空です。
+              </Form.Control.Feedback>
             </Form.Group>
           </Col>
           <Col md={2}>
             <Form.Group className="mb-3" controlId="sex">
               <Form.Label>性別 :</Form.Label>
-              <Form.Select aria-label="Default select example">
-                <option defaultValue="valid" disabled>--選択--</option>
-                <option value="1">男性</option>
-                <option value="2">女性</option>
-                <option value="3">無回答</option>
+              <Form.Select
+                required
+                aria-label="Default select example"
+                onChange={(event) => {
+                  console.log(event)
+                  setSex(event.target.value)
+                }}
+                isInvalid={submited && sexIsInvalid}
+              >
+                <option defaultValue="invalid" selected disabled>--選択--</option>
+                <option value="male">男性</option>
+                <option value="female">女性</option>
+                <option value="other">無回答</option>
               </Form.Select>
+              <Form.Control.Feedback type="invalid">
+                選択してください。
+              </Form.Control.Feedback>
             </Form.Group>
           </Col>
           <Col md={2}>
             <Form.Group className="mb-3" controlId="birthday">
               <Form.Label>お誕生日 :</Form.Label>
-              <Form.Control type='date' />
+              <Form.Control
+                required
+                type='date'
+                onChange={(event) => {
+                  setBirthday(event.target.value)
+                }}
+                isInvalid={submited && birthdayIsInvalid}
+              />
+              <Form.Control.Feedback type="invalid">
+                選択してください。
+              </Form.Control.Feedback>
             </Form.Group>
           </Col>
           <Col md={2}>
             <Form.Group className="mb-3" controlId="address">
               <Form.Label>住所 :</Form.Label>
-              <Form.Control type='input' />
+              <Form.Control
+                required
+                type='input'
+                onChange={(event) => {
+                  setAddress(event.target.value)
+                }}
+                isInvalid={submited && addressIsInvalid}
+              />
+              <Form.Control.Feedback type="invalid">
+                入力欄が空です。
+              </Form.Control.Feedback>
             </Form.Group>
           </Col>
           <Col md={2}>
             <Form.Group className="mb-3" controlId="work_yaer">
               <Form.Label>勤続年数 :</Form.Label>
-              <Form.Select aria-label="Default select example">
-                <option defaultValue="valid" disabled>--選択--</option>
+              <Form.Select
+                required
+                aria-label="Default select example"
+                onChange={(event) => {
+                  setWorkYear(event.target.value)
+                }}
+                isInvalid={submited && workYearIsInvalid}
+              >
+                <option defaultValue="invalid" selected disabled>--選択--</option>
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>
               </Form.Select>
+              <Form.Control.Feedback type="invalid">
+                選択してください。
+              </Form.Control.Feedback>
             </Form.Group>
           </Col>
           {/* TODO: submit時にvalidationかける必要あり */}
           <Col md={2}>
             <Form.Group className="mb-3" controlId="phone_number">
               <Form.Label>電話番号 :</Form.Label>
-              <Form.Control type='tel' />
+              <Form.Control
+                required
+                type='tel'
+                onChange={(event) => {
+                  setPhoneNumber(event.target.value)
+                }}
+                isInvalid={submited && phoneNumberIsInvalid}
+              />
+              <Form.Control.Feedback type="invalid">
+                入力欄が空か、適切な値ではありません。ハイフンを除いた半角数字11桁にしてください。
+              </Form.Control.Feedback>
             </Form.Group>
           </Col>
           <Col md={2}>
-            <Form.Group className="mb-3" controlId="checkbox">
+            <Form.Group className="mb-3" controlId="is_admin">
               <Form.Check
                 inline
                 label="この人は管理者です"
@@ -67,22 +156,35 @@ const AddEmployee = () => {
                 id="checkbox"
                 className='mx-2 mb-5'
                 onChange={(event) => {
-                  setCheck(event.target.checked)
+                  setIdAdmin(event.target.checked)
                 }}
               />
             </Form.Group>
           </Col>
           <Col md={2}>
-            {check &&
+            {isAdmin &&
               <Form.Group className="mb-3" controlId="admin_mail_address">
                 <Form.Label>管理者メールアドレス :</Form.Label>
-                <Form.Control type='input' />
+                <Form.Control
+                  type='input'
+                  onChange={(event) => {
+                    setAdminMailAddress(event.target.value)
+                  }}
+                  isInvalid={submited && adminMailAddressIsInvalid}
+                />
+                <Form.Control.Feedback type="invalid">
+                  入力欄が空か、適切な値ではありません。
+                </Form.Control.Feedback>
               </Form.Group>
             }
           </Col>
           <Col xs={8} />
           <Col xs={12} className='my-1 text-center'>
-            <Button variant="primary" type="submit" className='px-5' >
+            <Button
+              variant="primary"
+              type="submit"
+              className='px-5'
+            >
               登録
             </Button>
           </Col>

--- a/src/home/components/AddEmployee/index.jsx
+++ b/src/home/components/AddEmployee/index.jsx
@@ -62,7 +62,6 @@ const AddEmployee = () => {
                 required
                 aria-label="Default select example"
                 onChange={(event) => {
-                  console.log(event)
                   setSex(event.target.value)
                 }}
                 isInvalid={submited && sexIsInvalid}
@@ -130,7 +129,6 @@ const AddEmployee = () => {
               </Form.Control.Feedback>
             </Form.Group>
           </Col>
-          {/* TODO: submit時にvalidationかける必要あり */}
           <Col md={2}>
             <Form.Group className="mb-3" controlId="phone_number">
               <Form.Label>電話番号 :</Form.Label>

--- a/src/home/components/AddEmployee/store.js
+++ b/src/home/components/AddEmployee/store.js
@@ -1,0 +1,198 @@
+import React from "react";
+import { atom, selector, useRecoilValue, useSetRecoilState } from "recoil";
+
+const key = 'home/addEmployee'
+
+const state = atom({
+  key: `${key}/atom`,
+  default: {
+    name: "",
+    sex: "invalid",
+    birthday: "",
+    address: "",
+    work_yaer: "invalid",
+    phone_number: "",
+    is_admin: false,
+    admin_mail_address: "",
+    submited: false,
+  }
+})
+
+const isAdmin = selector({
+  key: `${key}/selector/isAdmin`,
+  get: ({ get }) => {
+    const currectState = get(state);
+
+    return currectState.is_admin ;
+  },
+});
+
+const submited = selector({
+  key: `${key}/selector/submited`,
+  get: ({ get }) => {
+    const currectState = get(state);
+
+    return currectState.submited ;
+  },
+});
+
+const nameIsInvalid = selector({
+  key: `${key}/selector/name/validate`,
+  get: ({ get }) => {
+    const { name } = get(state);
+    if (name === "") { return true }
+
+    return false ;
+  },
+});
+
+const sexIsInvalid = selector({
+  key: `${key}/selector/sex/validate`,
+  get: ({ get }) => {
+    const { sex } = get(state);
+    console.log("~~ sex ~~")
+    console.log(sex)
+    if (sex === "invalid") { return true }
+
+    return false ;
+  },
+});
+
+const birthdayIsInvalid = selector({
+  key: `${key}/selector/birthday/validate`,
+  get: ({ get }) => {
+    const { birthday } = get(state);
+    if (birthday === "") { return true }
+
+    return false ;
+  },
+});
+
+const addressIsInvalid = selector({
+  key: `${key}/selector/address/validate`,
+  get: ({ get }) => {
+    const { address } = get(state);
+    if (address === "") { return true }
+
+    return false ;
+  },
+});
+
+const workYaerIsInvalid = selector({
+  key: `${key}/selector/workYaer/validate`,
+  get: ({ get }) => {
+    const { work_yaer } = get(state);
+    if (work_yaer === "invalid") { return true }
+
+    return false ;
+  },
+});
+
+const phoneNumberIsInvalid = selector({
+  key: `${key}/selector/phoneNumber/validate`,
+  get: ({ get }) => {
+    const { phone_number } = get(state);
+    const phoneNumberRegex = /^\d{10}$|^\d{11}$/
+    if (!phoneNumberRegex.test(phone_number)) { return true }
+
+    return false ;
+  },
+});
+
+const adminMailAddressIsInvalid = selector({
+  key: `${key}/selector/adminMailAddress/validate`,
+  get: ({ get }) => {
+    const { admin_mail_address, is_admin } = get(state);
+    const adminMailAddressRegex = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/
+    if (is_admin === false) { return false }
+    if (!adminMailAddressRegex.test(admin_mail_address)) { return true }
+
+    return false ;
+  },
+});
+
+export const selectors = {
+  useIsAdmin: () => useRecoilValue(isAdmin),
+  useSubmited: () => useRecoilValue(submited),
+  useSexIsInvalid: () => useRecoilValue(sexIsInvalid),
+  useNameIsInvalid: () => useRecoilValue(nameIsInvalid),
+  useBirthdayIsInvalid: () => useRecoilValue(birthdayIsInvalid),
+  useAddressIsInvalid: () => useRecoilValue(addressIsInvalid),
+  useWorkYaerIsInvalid: () => useRecoilValue(workYaerIsInvalid),
+  usePhoneNumberIsInvalid: () => useRecoilValue(phoneNumberIsInvalid),
+  useAdminMailAddressIsInvalid: () => useRecoilValue(adminMailAddressIsInvalid),
+}
+
+export const actions = {
+  useSetName: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((name) => {
+      setState((prev) => ({ ...prev, name: name }))
+    }, [setState])
+  }),
+
+  useSetSex: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((sex) => {
+      setState((prev) => ({ ...prev, sex: sex }))
+    }, [setState])
+  }),
+
+  useSetBirthday: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((birthday) => {
+      setState((prev) => ({ ...prev, birthday: birthday }))
+    }, [setState])
+  }),
+
+  useSetAddress: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((address) => {
+      setState((prev) => ({ ...prev, address: address }))
+    }, [setState])
+  }),
+
+  useSetWorkYaer: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((workYaer) => {
+      setState((prev) => ({ ...prev, work_yaer: workYaer }))
+    }, [setState])
+  }),
+
+  useSetPhoneNumber: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((phoneNumber) => {
+      setState((prev) => ({ ...prev, phone_number: phoneNumber }))
+    }, [setState])
+  }),
+
+  useSetIsAdmin: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((isAdmin) => {
+      setState((prev) => ({ ...prev, is_admin: isAdmin }))
+    }, [setState])
+  }),
+
+  useSetAdminMailAddress: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((adminMailAddress) => {
+      setState((prev) => ({ ...prev, admin_mail_address: adminMailAddress }))
+    }, [setState])
+  }),
+
+  useSetTrueSubmited: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback(() => {
+      setState((prev) => ({ ...prev, submited: true }))
+    }, [setState])
+  })
+}

--- a/src/home/components/AddEmployee/store.js
+++ b/src/home/components/AddEmployee/store.js
@@ -50,8 +50,6 @@ const sexIsInvalid = selector({
   key: `${key}/selector/sex/validate`,
   get: ({ get }) => {
     const { sex } = get(state);
-    console.log("~~ sex ~~")
-    console.log(sex)
     if (sex === "invalid") { return true }
 
     return false ;

--- a/src/home/components/Employees/index.jsx
+++ b/src/home/components/Employees/index.jsx
@@ -1,14 +1,10 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { Button, Container, Table } from 'react-bootstrap'
+import { actions, selectors } from './store'
 
 const Employees = () => {
-  const [employees, setEmployees] = useState()
-
-  const getEmployees = useCallback(async () => {
-    await fetch('http://localhost:3002/employees', { method: 'GET' })
-      .then(response => response.json())
-      .then(data => setEmployees(data));
-  }, [])
+  const employees = selectors.useEmployees()
+  const fetchEmployees = actions.useFetchEmployees()
 
   const calc_age = (birthdayStr) => {
     const birthday = new Date(birthdayStr);
@@ -24,8 +20,8 @@ const Employees = () => {
   }
 
   useEffect(() => {
-    getEmployees()
-  }, [getEmployees])
+    fetchEmployees()
+  }, [fetchEmployees])
 
   return (
     <Container>

--- a/src/home/components/Employees/store.js
+++ b/src/home/components/Employees/store.js
@@ -1,0 +1,44 @@
+import React from "react";
+import { atom, selector, useRecoilValue, useSetRecoilState } from "recoil";
+import Employees from "../../datasources/Employees";
+
+const key = 'home/employees'
+
+const state = atom({
+  key: `${key}/atom`,
+  default: {
+    loading: false,
+    employees: [],
+  }
+})
+
+const employees = selector({
+  key: `${key}/selector/employees`,
+  get: ({ get }) => {
+    const { employees } = get(state);
+
+    return employees ;
+  },
+});
+
+export const selectors = {
+  useEmployees: () => useRecoilValue(employees),
+}
+
+export const actions = {
+  useFetchEmployees: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback(async () => {
+      setState((prev) => ({ ...prev, loading: true }))
+      try {
+        const res = await Employees.get()
+        setState((prev) => ({ ...prev, employees: res.data }))
+      } catch (e) {
+        throw e
+      } finally {
+        setState((prev) => ({ ...prev, loading: false }))
+      }
+    }, [setState])
+  })
+}

--- a/src/home/components/Employees/store.js
+++ b/src/home/components/Employees/store.js
@@ -8,7 +8,7 @@ const state = atom({
   key: `${key}/atom`,
   default: {
     loading: false,
-    employees: [],
+    employees: null,
   }
 })
 

--- a/src/home/components/SearchCondition/index.jsx
+++ b/src/home/components/SearchCondition/index.jsx
@@ -1,56 +1,113 @@
 import { Button, Container, Form, Row, Col } from 'react-bootstrap'
+import { actions, selectors } from './store'
 
 const SearchCondition = () => {
+  const searched = selectors.useSearched()
+  const phoneNumberIsInvalid = selectors.usePhoneNumberIsInvalid()
+  const setName = actions.useSetName()
+  const setSex = actions.useSetSex()
+  const setBirthday = actions.useSetBirthday()
+  const setAddress = actions.useSetAddress()
+  const setWorkYear = actions.useSetWorkYaer()
+  const setPhoneNumber = actions.useSetPhoneNumber()
+  const search = actions.useSearch()
+
+  const handleSubmit = (event) => {
+    const form = event.currentTarget;
+    search()
+    if (form.checkValidity() === false) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
   return (
     <Container>
       <h2 className='text-primary'>絞り込み検索</h2>
-      <Form className='shadow bg-white rounded p-3'>
+      <Form
+        noValidate
+        className='shadow bg-white rounded p-3'
+        onSubmit={handleSubmit}
+      >
         <Row className="justify-content-center">
           <Col md={2}>
             <Form.Group className="mb-3" controlId="name">
               <Form.Label>お名前 :</Form.Label>
-              <Form.Control type='input' />
+              <Form.Control
+                type='input'
+                onChange={(event) => {
+                  setName(event.target.value)
+                }}
+              />
             </Form.Group>
           </Col>
           <Col md={2}>
             <Form.Group className="mb-3" controlId="sex">
               <Form.Label>性別 :</Form.Label>
-              <Form.Select aria-label="Default select example">
-                <option defaultValue="valid" disabled>--選択--</option>
-                <option value="1">男性</option>
-                <option value="2">女性</option>
-                <option value="3">無回答</option>
+              <Form.Select
+                aria-label="Default select example"
+                onChange={(event) => {
+                  setSex(event.target.value)
+                }}
+              >
+                <option defaultValue="" selected>--選択--</option>
+                <option value="male">男性</option>
+                <option value="female">女性</option>
+                <option value="other">無回答</option>
               </Form.Select>
             </Form.Group>
           </Col>
           <Col md={2}>
             <Form.Group className="mb-3" controlId="birthday">
               <Form.Label>お誕生日 :</Form.Label>
-              <Form.Control type='date' />
+              <Form.Control
+                type='date'
+                onChange={(event) => {
+                  setBirthday(event.target.value)
+                }}
+              />
             </Form.Group>
           </Col>
           <Col md={2}>
             <Form.Group className="mb-3" controlId="address">
               <Form.Label>住所 :</Form.Label>
-              <Form.Control type='input' />
+              <Form.Control
+                type='input'
+                onChange={(event) => {
+                  setAddress(event.target.value)
+                }}
+              />
             </Form.Group>
           </Col>
           <Col md={2}>
-            <Form.Group className="mb-3" controlId="work-year">
+            <Form.Group className="mb-3" controlId="work_yaer">
               <Form.Label>勤続年数 :</Form.Label>
-              <Form.Select aria-label="Default select example2">
-                <option defaultValue="valid" disabled>--選択--</option>
+              <Form.Select
+                aria-label="Default select example"
+                onChange={(event) => {
+                  setWorkYear(event.target.value)
+                }}
+              >
+                <option defaultValue="" selected>--選択--</option>
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>
               </Form.Select>
             </Form.Group>
           </Col>
-          {/* TODO: submit時にvalidationかける必要あり */}
           <Col md={2}>
             <Form.Group className="mb-3" controlId="phone_number">
               <Form.Label>電話番号 :</Form.Label>
-              <Form.Control type='tel' />
+              <Form.Control
+                type='tel'
+                onChange={(event) => {
+                  setPhoneNumber(event.target.value)
+                }}
+                isInvalid={searched && phoneNumberIsInvalid}
+              />
+              <Form.Control.Feedback type="invalid">
+                適切な値ではありません。ハイフンを除いた半角数字11桁にしてください。
+              </Form.Control.Feedback>
             </Form.Group>
           </Col>
           <Col xs='auto' className='my-1'>

--- a/src/home/components/SearchCondition/store.js
+++ b/src/home/components/SearchCondition/store.js
@@ -1,0 +1,123 @@
+import React from "react";
+import { atom, selector, useRecoilValue, useSetRecoilState } from "recoil";
+
+const key = 'home/searchCondition'
+
+const state = atom({
+  key: `${key}/atom`,
+  default: {
+    name: "",
+    sex: "",
+    birthday: "",
+    address: "",
+    work_yaer: null,
+    phone_number: "",
+    is_admin: false,
+    admin_mail_address: "",
+    searched: false,
+  }
+})
+
+const searched = selector({
+  key: `${key}/selector/searched`,
+  get: ({ get }) => {
+    const currectState = get(state);
+
+    return currectState.searched ;
+  },
+});
+
+const phoneNumberIsInvalid = selector({
+  key: `${key}/selector/phoneNumber/validate`,
+  get: ({ get }) => {
+    const { phone_number } = get(state);
+    const phoneNumberRegex = /^\d{10}$|^\d{11}$/
+    if(phone_number === '') { return false }
+    if(!phoneNumberRegex.test(phone_number)) { return true }
+
+    return false ;
+  },
+});
+
+export const selectors = {
+  useSearched: () => useRecoilValue(searched),
+  usePhoneNumberIsInvalid: () => useRecoilValue(phoneNumberIsInvalid),
+}
+
+export const actions = {
+  useSetName: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((name) => {
+      setState((prev) => ({ ...prev, name: name }))
+    }, [setState])
+  }),
+
+  useSetSex: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((sex) => {
+      setState((prev) => ({ ...prev, sex: sex }))
+    }, [setState])
+  }),
+
+  useSetBirthday: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((birthday) => {
+      setState((prev) => ({ ...prev, birthday: birthday }))
+    }, [setState])
+  }),
+
+  useSetAddress: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((address) => {
+      setState((prev) => ({ ...prev, address: address }))
+    }, [setState])
+  }),
+
+  useSetWorkYaer: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((workYaer) => {
+      setState((prev) => ({ ...prev, work_yaer: workYaer }))
+    }, [setState])
+  }),
+
+  useSetPhoneNumber: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((phoneNumber) => {
+      setState((prev) => ({ ...prev, phone_number: phoneNumber }))
+    }, [setState])
+  }),
+
+  useSetIsAdmin: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((isAdmin) => {
+      setState((prev) => ({ ...prev, is_admin: isAdmin }))
+    }, [setState])
+  }),
+
+  useSetAdminMailAddress: (() => {
+    const setState = useSetRecoilState(state)
+
+    return React.useCallback((adminMailAddress) => {
+      setState((prev) => ({ ...prev, admin_mail_address: adminMailAddress }))
+    }, [setState])
+  }),
+
+  useSearch: (() => {
+    const setState = useSetRecoilState(state)
+    const stateValue = useRecoilValue(state)
+
+    return React.useCallback(() => {
+      // TODO: API側ができたらリクエストを送信して、状態変化させる
+      console.log('検索しました')
+      console.log(stateValue)
+      setState((prev) => ({ ...prev, searched: true }))
+    }, [setState, stateValue])
+  })
+}

--- a/src/home/datasources/Employees.js
+++ b/src/home/datasources/Employees.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+export default class Employees {
+  static async get(params) {
+    try {
+      // TODO: API完成時に入れ替える
+      const URL = 'http://localhost:3002/employees'
+      return await axios.get( URL, { params: params });
+    } catch (error) {
+      throw error
+    }
+  }
+}


### PR DESCRIPTION
## チケットへのリンク

* https://github.com/NODASHUSEINANODA/ohana/issues/9

## やったこと

* ホーム画面の状態管理をrecoilに書き換え
* 絞り込み検索にもバリデーションを追加
  * どの値も基本的に空を許容すると思うので、電話番号のカラムだけ、①値が空ではなく②電話番号のフォーマットに沿っていない時に送信させないようにした
* httpクライアントとしてaxiosをインストール
* 不要なログやコメントアウトを削除

## やらないこと

* APIを叩く際の例外キャッチ後の処理(別でチケット化して対応)
  * [react-bootstrapのAlertsコンポーネント](https://react-bootstrap.github.io/components/alerts/)でできそう
* メンバー一覧のローディングの際にぐるぐるローディングようのコンポーネントを追加しても良さそう(やる時は別チケット作成して対応します)

## できるようになること（ユーザ目線）

* 絞り込み検索の電話番号にフォーマットに沿っていない値を入れるとエラーの表示になる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* バリデーションの操作確認(アルファベットなどを打ってみて確認)

## その他
- なし

## スクショ
- 特に変化ないので載せてません