### PR TITLE
Issue/#12

### DIFF
--- a/copilot/.workspace
+++ b/copilot/.workspace
@@ -1,0 +1,1 @@
+application: one-step-gift

--- a/copilot/environments/test/manifest.yml
+++ b/copilot/environments/test/manifest.yml
@@ -1,0 +1,21 @@
+# The manifest for the "test" environment.
+# Read the full specification for the "Environment" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/environment/
+
+# Your environment name will be used in naming your resources like VPC, cluster, etc.
+name: test
+type: Environment
+
+# Import your own VPC and subnets or configure how they should be created.
+# network:
+#   vpc:
+#     id:
+
+# Configure the load balancers in your environment, once created.
+# http:
+#   public:
+#   private:
+
+# Configure observability for your environment resources.
+observability:
+  container_insights: false

--- a/copilot/frontend/manifest.yml
+++ b/copilot/frontend/manifest.yml
@@ -42,7 +42,7 @@ network:
 
 # You can override any of the values defined above by environment.
 environments:
-  dev:
-    count: 1               # Number of tasks to run for the "dev" environment.
-    deployment:            # The deployment strategy for the "dev" environment.
+  test:
+    count: 1               # Number of tasks to run for the "test" environment.
+    deployment:            # The deployment strategy for the "test" environment.
       rolling: 'recreate' # Stops existing tasks before new ones are started for faster deployments.

--- a/copilot/frontend/manifest.yml
+++ b/copilot/frontend/manifest.yml
@@ -1,0 +1,48 @@
+# The manifest for the "frontend" service.
+# Read the full specification for the "Load Balanced Web Service" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/
+
+# Your service name will be used in naming your resources like log groups, ECS services, etc.
+name: frontend
+type: Load Balanced Web Service
+
+# Distribute traffic to your service.
+http:
+  # Requests to this path will be forwarded to your service.
+  # To match all requests you can use the "/" path.
+  path: '/'
+  # You can specify a custom health check path. The default is "/".
+  healthcheck: '/healthcheck'
+
+# Configuration for your containers and service.
+image:
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-build
+  build: Dockerfile
+  # Port exposed through your container to route traffic to it.
+  port: 80
+
+cpu: 256       # Number of CPU units for the task.
+memory: 512    # Amount of memory in MiB used by the task.
+platform: linux/x86_64  # See https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#platform
+count: 1       # Number of tasks that should be running in your service.
+exec: true     # Enable running commands in your container.
+network:
+  connect: true # Enable Service Connect for intra-environment traffic between services.
+
+# storage:
+  # readonly_fs: true       # Limit to read-only access to mounted root filesystems.
+
+# Optional fields for more advanced use-cases.
+#
+#variables:                    # Pass environment variables as key value pairs.
+#  LOG_LEVEL: info
+
+#secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
+#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
+
+# You can override any of the values defined above by environment.
+environments:
+  dev:
+    count: 1               # Number of tasks to run for the "dev" environment.
+    deployment:            # The deployment strategy for the "dev" environment.
+      rolling: 'recreate' # Stops existing tasks before new ones are started for faster deployments.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,22 +1,23 @@
 server_tokens off;
 
 # 指定server_name(hostヘッダ)以外のリクエストはhealthcheck以外403を返す
+# server {
+#     listen 80 default_server;
+#     server_name _;
+#     location /healthcheck {
+#         add_header Content-Type "text/html";
+#         return 200 OK;
+#     }
+#     location / {
+#         return 403;
+#     }
+# }
+
+# TODO: ドメインが決まったらサンプルで書いているドメインを上書きする(one-step-gift.jp, stg-one-step-gift.jp)
+# TODO: ドメインを取得でき次第、listen 80 と server_name ドメイン名 を設定して、上のserverのコメントを外す
 server {
     listen 80 default_server;
     server_name _;
-    location /healthcheck {
-        add_header Content-Type "text/html";
-        return 200 OK;
-    }
-    location / {
-        return 403;
-    }
-}
-
-# TODO: ドメインが決まったらサンプルで書いているドメインを上書きする(one-step-gift.jp, stg-one-step-gift.jp)
-server {
-    listen 80;
-    server_name one-step-gift.jp stg-one-step-gift.jp;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers ECDHE+RSAGCM:ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:!EXPORT:!DES:!3DES:!MD5:!DSS;
     gzip on;


### PR DESCRIPTION
## チケットへのリンク

* close #12 

## やったこと

* aws copilotでインフラを作成

## やらないこと

* https化
  * ドメインが決まって証明書がある状態になれば、別環境(copilotのenvironment)を追加してhttps化する

## できるようになること（ユーザ目線）

* 以下のURLでfrontが見れる
  * http://one-s-publi-17lwvpces3boo-1881057475.ap-northeast-1.elb.amazonaws.com/

## できなくなること（ユーザ目線）

* なし

## 動作確認

* URLにアクセスして、表示されるか確認した

## その他

* デプロイの手順とか、まだ整理していないので、デプロイは玉城の担当でお願いします！！mm
* 本番環境は会社のAWS垢で動かすので、一旦会社に任意のドメインを購入してもらう必要がありそう
* もしかしたら、会社に自分たちのAWSのIAMユーザーを作成してもらって、リソースの作成はそのアカウントでログインして行うとかがリソースの移行の手間が少ないかも、とりあえずドメイン周りは要検討。。。

## キャプチャ
